### PR TITLE
feat: recompile pcre with utf-8 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ MAINTAINER Jonathan Barnett (jonathan.barnett@news.com.au)
 
 ENV ETS_VER     akamai-ets_6.0.0.4_Ubuntu
 ENV ETS_DIR     /opt/akamai-ets
+ENV PCRE_VER    8.33
 
 ENV NODE_DIR    /usr/src/app/
 ENV HTTPD_DIR   /usr/local/apache2
@@ -26,15 +27,30 @@ RUN echo "foreign-architecture i386" > /etc/dpkg/dpkg.cfg.d/multiarch && \
     libexpat1:i386 \
     libssl1.0.0:i386 \
     libstdc++6:i386 \
-    zlibc:i386
+    zlibc:i386 \
+    gcc-multilib \
+    g++-multilib
 
 # install ets server directly bypassing default
 # installation
 
 COPY files/release/${ETS_VER}.tar.gz /tmp
 
-RUN  tar -xzf /tmp/${ETS_VER}.tar.gz -C /tmp && \
-     cd /tmp/${ETS_VER}/files && ./install-bindist.sh ${HTTPD_DIR} && \
+RUN  tar -xzf /tmp/${ETS_VER}.tar.gz -C /tmp
+
+# update existing pcre to include utf-8 support
+RUN cd /tmp && \
+    curl http://ftp.cs.stanford.edu/pub/exim/pcre/pcre-${PCRE_VER}.tar.gz > pcre-${PCRE_VER}.tar.gz && \
+    tar -xzf pcre-${PCRE_VER}.tar.gz && \
+    cd /tmp/pcre-${PCRE_VER} && \
+    ./configure --prefix=/tmp/akamai-ets_6.0.0.4_Ubuntu/files/bindist \
+      --enable-utf8 \
+      --enable-unicode-properties \
+      --build=i686-pc-linux-gnu "CFLAGS=-m32" "CXXFLAGS=-m32" "LDFLAGS=-m32" && \
+    make && \
+    make install
+
+RUN  cd /tmp/${ETS_VER}/files && ./install-bindist.sh ${HTTPD_DIR} && \
      rm -rf /tmp/*
 
 RUN  ln -s ${HTTPD_DIR} ${ETS_DIR}

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN cd /tmp && \
     curl http://ftp.cs.stanford.edu/pub/exim/pcre/pcre-${PCRE_VER}.tar.gz > pcre-${PCRE_VER}.tar.gz && \
     tar -xzf pcre-${PCRE_VER}.tar.gz && \
     cd /tmp/pcre-${PCRE_VER} && \
-    ./configure --prefix=/tmp/akamai-ets_6.0.0.4_Ubuntu/files/bindist \
+    ./configure --prefix=/tmp/${ETS_VER}/files/bindist \
       --enable-utf8 \
       --enable-unicode-properties \
       --build=i686-pc-linux-gnu "CFLAGS=-m32" "CXXFLAGS=-m32" "LDFLAGS=-m32" && \


### PR DESCRIPTION
I've found that out of the box the akamai ets wasn't able to match regular expressions successfully.

For example this code tests if a string matches against a regular expression:

```
<!--esi
<esi:assign name="regex" value="'''^cheese$'''" />
  <esi:choose>
  <esi:when test="'cheese' matches $(regex)">
    <esi:text>Matches</esi:text>
  </esi:when>
  <esi:otherwise>
    <esi:text>Fail</esi:text>
  </esi:otherwise>
  </esi:choose>
-->
```

it should print "Matches" but always prints "Fail"

ESI debugging warns that PCRE not has not been compiled with UTF support:

```
Warning: [2012]: Line 3. Bad regular expression "^cheese$", this version of PCRE is compiled without UTF support.
[2003]: Line 3. WHEN expression evaluated FALSE.
```

Therefore I've updated the Dockerfile to download the matching version of PCRE and compile it with UTF support.

Regular expressions should then work correctly.
